### PR TITLE
Correctly refer to column in Getting Started writeup

### DIFF
--- a/content/en/docs/Getting started/_index.md
+++ b/content/en/docs/Getting started/_index.md
@@ -35,7 +35,7 @@ environment. We assume you have already obtained the libraries via a package man
 ### Data
 
 ```lisp
-(defparameter cars
+(defdf cars
   (dfio:vl-to-df
     (dex:get
 	  "https://raw.githubusercontent.com/vega/vega-datasets/master/data/cars.json"


### PR DESCRIPTION
I was walking through the [Getting Started](https://lisp-stat.dev/docs/getting-started/) writeup and spotted this. I will note that the `(summary cars)` line from that document also did not work for me, but I am not sure of the right fix.